### PR TITLE
remove unnecessary include

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -1,11 +1,6 @@
 // Too many calls to quantile lead to high failure rate for `scrappie raw`
 #define BANANA 1
 #include <assert.h>
-#ifdef __APPLE__
-#    include <Accelerate/Accelerate.h>
-#else
-#    include <cblas.h>
-#endif
 #include <err.h>
 #include <math.h>
 #include "scrappie_stdlib.h"


### PR DESCRIPTION
As discussed over email, I want to use some scrappie code in nanopolish. I need to use `util.[hc]` which has an unused include of `cblas.h` - this PR removes it.